### PR TITLE
Option to define a custom service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ Ansible Role: Prometheus Exporter Installer
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-prometheus--exporter--installer-blue.svg)](https://galaxy.ansible.com/Lusitaniae/prometheus-exporter-installer)
 
 
-Role for installing prometheus exporters in your server.
+Role for installing Prometheus exporters in your server.
 
 Should work for _all_ exporters with a similar release procedure as the official ones. Where *promu* is used to build and package the exporters for a number of architectures and deploy the final packages to the respective release in GitHub.
 
-Usecase
+Use case
 ------------
 
-Installing one or more exporters in a system. 
+Installing one or more exporters in a system.
 
 Useful when you're running traditional VMs which you may be sharing for multiple services.
+
 
 
 Requirements
@@ -33,6 +34,8 @@ Example Playbook
 
   vars:
     prometheus_exporter_install_plugins:
+     # the github values below are used to build the download url, like this:
+     # https://github.com/{{ item.github_user }}/{{ item.github_name }}/releases/download/v{{ item.github_version }}/{{ item.github_name }}-{{ item.github_version }}.{{ ansible_system|lower }}-386.tar.gz"
      - name: Apache Exporter
        github_user: Lusitaniae
        github_name: apache_exporter
@@ -44,9 +47,9 @@ Example Playbook
        github_name: memcached_exporter
        github_version: 0.3.0
        exporter_args:
-     
-     # This exporter has different naming convention, 
-     # so you can override download url using github_release
+
+     # This exporter has different naming convention,
+     # you can override download url using github_release
      - name: Redis Exporter
        github_user: oliver006
        github_name: redis_exporter
@@ -54,6 +57,19 @@ Example Playbook
        github_release: https://github.com/oliver006/redis_exporter/releases/download/v1.27.0/redis_exporter-v1.27.0.linux-386.tar.gz
        install_path: /usr/local/bin/redis_exporter
        exporter_args: "--redis.addr=redis://{{ redis_hostname }}:6379"
+
+     # example of running multiple redis exporters
+     - name: Redis Exporter Production
+       github_user: oliver006
+       github_name: redis_exporter
+       # by default the systemd service name file name github_name.service
+       # if you want to run multiple exporters, define service_name
+       service_name: redis_exporter_production
+       github_version: 1.27.0
+       github_release: https://github.com/oliver006/redis_exporter/releases/download/v1.27.0/redis_exporter-v1.27.0.linux-386.tar.gz
+       install_path: /usr/local/bin/redis_exporter
+       exporter_args: "--redis.addr=redis://{{ redis_hostname }}:6379"
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example Playbook
        github_version: 1.27.0
        github_release: https://github.com/oliver006/redis_exporter/releases/download/v1.27.0/redis_exporter-v1.27.0.linux-386.tar.gz
        install_path: /usr/local/bin/redis_exporter
-       exporter_args: "--redis.addr=redis://{{ redis_hostname }}:6379"
+       exporter_args: "--web.listen-address 0.0.0.0:9122 --redis.addr=redis://{{ redis_hostname }}:6379"
 
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,13 +39,13 @@
 - name: Setup exporters as system services.
   template:
     src: exporter.service.j2
-    dest: "/etc/systemd/system/{{ item.github_name }}.service"
+    dest: "/etc/systemd/system/{{ item.service_name | default(item.github_name) }}.service"
     mode: 0644
   with_items: "{{ prometheus_exporter_install_plugins }}"
 
 - name: Ensure exporters are enabled and started as system services.
   systemd:
-    name: "{{ item.github_name }}"
+    name: "{{ item.service_name | default(item.github_name) }}"
     state: started
     enabled: yes
   with_items: "{{ prometheus_exporter_install_plugins }}"


### PR DESCRIPTION
In case I want to run multiple exporters from a server, e.g. blackbox exporter or redis exporter

Usage (added to Readme)

```
     # example of running multiple redis exporters
     - name: Redis Exporter Production
       github_user: oliver006
       github_name: redis_exporter
       # by default the systemd service name file name github_name.service
       # if you want to run multiple exporters, define service_name
       service_name: redis_exporter_production
       github_version: 1.27.0
       github_release: https://github.com/oliver006/redis_exporter/releases/download/v1.27.0/redis_exporter-v1.27.0.linux-386.tar.gz
       install_path: /usr/local/bin/redis_exporter
       exporter_args: "--web.listen-address 0.0.0.0:9122 --redis.addr=redis://{{ redis_hostname }}:6379"

```