### PR TITLE
Customize exporter directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 exporter_username: exporter
+prometheus_exporter_install_directory: "/usr/local/bin"
 prometheus_exporter_install_plugins:
 # Examples
 # - name: Apache Exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Create exporters directory.
   file:
-    path: "/usr/local/bin/{{ item.github_name }}"
+    path: "{{ prometheus_exporter_install_directory }}/{{ item.github_name }}"
     state: directory
   with_items: "{{ prometheus_exporter_install_plugins }}"
 
@@ -32,7 +32,7 @@
   unarchive:
     remote_src: yes
     src: "/tmp/{{ item.github_name }}.tar.gz"
-    dest: "/usr/local/bin/{{ item.github_name }}"
+    dest: "{{ prometheus_exporter_install_directory }}/{{ item.github_name }}"
     extra_opts: "--strip-components=1" # remove first level directory
   with_items: "{{ prometheus_exporter_install_plugins }}"
 

--- a/templates/exporter.service.j2
+++ b/templates/exporter.service.j2
@@ -10,7 +10,7 @@ Type=simple
 User={{ exporter_username }}
 Group={{ exporter_username }}
 Restart=on-failure
-ExecStart=/usr/local/bin/{{ item.github_name }}/{{ item.github_name }} {{ item.exporter_args }}
+ExecStart={{ prometheus_exporter_install_directory }}/{{ item.github_name }}/{{ item.github_name }} {{ item.exporter_args }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We would like to customize the exporter directory instead of having the hardcoded path "/usr/local/bin".
A new variable "prometheus_exporter_install_directory" is added, its default value is "/usr/local/bin".
Tasks and templates have been updated accordingly.