### PR TITLE
Add variable to download archive

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ prometheus_exporter_install_plugins:
 #   github_name: memcached_exporter
 #   github_version: 0.3.0
 #   systemd_args:
+prometheus_exporter_arch: 386

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Download exporter releases.
   get_url:
-    url: "https://github.com/{{ item.github_user }}/{{ item.github_name }}/releases/download/v{{ item.github_version }}/{{ item.github_name }}-{{ item.github_version }}.{{ ansible_system|lower }}-386.tar.gz"
+    url: "https://github.com/{{ item.github_user }}/{{ item.github_name }}/releases/download/v{{ item.github_version }}/{{ item.github_name }}-{{ item.github_version }}.{{ ansible_system|lower }}-{{ prometheus_exporter_arch }}.tar.gz"
     dest: "/tmp/{{ item.github_name }}.tar.gz"
     mode: 0644
   with_items: "{{ prometheus_exporter_install_plugins }}"


### PR DESCRIPTION
Hello,
In some cases, the architecture of some exporters is not 386 (amd64 for example). Do I've added a default parameter that is "386" (for retro compatibility) and updated the download path to use this variable.